### PR TITLE
Bump org.jetbrains.intellij from 1.8.0 to 1.16.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'org.jetbrains.kotlin.jvm' version '1.9.21'
-    id 'org.jetbrains.intellij' version '1.8.0'
+    id 'org.jetbrains.intellij' version '1.16.1'
     id 'org.jetbrains.changelog' version '1.3.1'
 }
 


### PR DESCRIPTION
Bumps org.jetbrains.intellij from 1.8.0 to 1.16.1.

---
updated-dependencies:
- dependency-name: org.jetbrains.intellij dependency-type: direct:production update-type: version-update:semver-minor ...