### PR TITLE
Add step to maximize build space in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,12 @@ jobs:
       version: ${{ steps.properties.outputs.version }}
       changelog: ${{ steps.properties.outputs.changelog }}
     steps:
+      - name: Maximize Build Space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+
       - name: Fetch Sources
         uses: actions/checkout@v4
 


### PR DESCRIPTION
A new step has been added to the GitHub Actions workflow in the file `build.yml`. This step uses the action `jlumbroso/free-disk-space@main` which helps to maximize the available disk space during the build process.